### PR TITLE
Switch order of if clause because of ie9

### DIFF
--- a/finder.js
+++ b/finder.js
@@ -754,8 +754,8 @@ var finders = {}
 
 var finder = function(context){
     var doc = context || document
-    if (doc.document) doc = doc.document
-    else if (doc.ownerDocument) doc = doc.ownerDocument
+    if (doc.ownerDocument) doc = doc.ownerDocument
+    else if (doc.document) doc = doc.document
 
     if (doc.nodeType !== 9) throw new TypeError("invalid document")
 


### PR DESCRIPTION
ie9 throws error when doing

``` javascript
$(zen('div').html(html).children()[0])
```

because div has .document in ie9
