### PR TITLE
finder: Always pass a string to the native querySelectorAll

### DIFF
--- a/finder.js
+++ b/finder.js
@@ -311,7 +311,7 @@ var Finder = function Finder(document){
             }
 
             if (!result) try {
-                result = node.querySelectorAll(expression)
+                result = node.querySelectorAll(expression.toString())
             } catch(e){
                 if (slick.debug) console.warn("querySelectorAll failed on " + (_expression || expression))
                 result = this.failed[_expression || expression] = true


### PR DESCRIPTION
We should be explicit and pass the type that the method expects,
and not trust the implementation to do a type coercion.
