### PR TITLE
Use window instead of global

### DIFF
--- a/finder.js
+++ b/finder.js
@@ -20,7 +20,7 @@ var index = 0,
     key = "uid:" + counter
 
 var uniqueID = function(n, xml){
-    if (n === global) return "global"
+    if (n === window) return "window"
     if (n === document) return "document"
     if (n === document.documentElement) return "html"
 


### PR DESCRIPTION
We expect global to be window, so we can just use window directly.
Using global caused problems when running tests with jsdom, since
we then create a new window object, but we can't replace global
with that, we can only assign the new window to global.window.
