### PR TITLE
slick.match in :not pseudo

### DIFF
--- a/finder.js
+++ b/finder.js
@@ -589,7 +589,7 @@ var pseudos = {
     },
 
     'not': function(expression){
-        return !slick.match(this, expression)
+        return !slick.matches(this, expression)
     },
 
     'contains': function(text){


### PR DESCRIPTION
`slick.match` should really be `slick.matches`, shouldn't it?